### PR TITLE
Fix shell command case in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ python WoodPuzzle_GUI.py
 ### Shell Version
 The game also includes a console-based version for those who prefer to play in a terminal environment:
 ```bash
-python WoodPuzzle_Shell.py
+python WoodPuzzle_shell.py
 ```
 The shell version provides the same gameplay mechanics but with a text-based interface, making it suitable for environments where graphical display is unavailable or for users who prefer command-line interfaces.
 


### PR DESCRIPTION
## Summary
- correct the casing for the shell version script in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683ffbeee4c0832e8cac82a83b4df659